### PR TITLE
add localstack aws ingress

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -128,6 +128,7 @@ tasks:
         && kubectl apply -f ./crossplane/provider-aws.yaml; sleep 3 \
         && kubectl apply -f ./applications/app-localstack.yaml; sleep 3 \
         && kubectl apply -f ./localstack/localstack-aws-secret.yaml; sleep 3 \
+        && kubectl apply -f ./localstack/localstack-aws-ingress.yaml; sleep 3 \
         && kubectl apply -f ./crossplane/providerconfig-crossplane-localstack.yaml
       - echo "Crossplane localstack provider config deployed successfully!"
 
@@ -139,6 +140,7 @@ tasks:
       - kubectl delete -f ./crossplane/providerconfig-crossplane-localstack.yaml || echo "Crossplane localstack provider config already deleted."
       - kubectl delete -f ./crossplane/provider-aws.yaml || echo "Crossplane AWS provider already deleted."
       - kubectl delete -f ./localstack/localstack-aws-secret.yaml || echo "Localstack AWS secret already deleted."
+      - kubectl delete -f ./localstack/localstack-aws-ingress.yaml || echo "Localstack AWS ingress already deleted."
       - kubectl delete -f ./applications/app-crossplane.yaml || echo "Crossplane already deleted."
       - kubectl delete -f ./localstack/app-localstack.yaml || echo "Localstack already deleted."
       - kubectl delete namespace localstack || echo "localstack namespace already deleted."

--- a/localstack/localstack-aws-ingress.yaml
+++ b/localstack/localstack-aws-ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: localstack-ingress
+  namespace: localstack
+spec:
+  rules:
+  - host: localstack.internal.localtest.me
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: localstack
+            port:
+              number: 4566
+
+


### PR DESCRIPTION
The AWS localstack provider ingress is added to the current flow.

Test method:
```bash
(devbox) ubuntu@sandbox:~/work/local-dev-k8s-crossplane-localstack$ aws ec2 describe-vpcs --profile localstack --endpoint-url http://localstack.internal.localtest.me:8080
{
    "Vpcs": [
       ...
    ]
}
```